### PR TITLE
Add Geany-Themes page with theme preview

### DIFF
--- a/geany/templates/home.html
+++ b/geany/templates/home.html
@@ -151,7 +151,7 @@ Home
 			<h2 class="text-center">Easily Customizable</h2>
 			<p>
 				Many parts of Geany are heavily customizable like color themes
-				(<a href="https://github.com/geany/geany-themes">Geany Themes project</a>) or
+				(<a href="{% url "page" "download/themes" %}">Geany Themes</a>) or
 				adding new filetypes.
 			</p>
 			<p>

--- a/page_content/download/themes.md
+++ b/page_content/download/themes.md
@@ -1,0 +1,10 @@
+## Geany Themes
+
+Geany-Themes is a collection of color schemes for Geany, either written originally by the Geany community or ported from color schemes for other editors.
+These schemes are compatible with Geany 1.22 and greater.
+
+To use one the themes below, download the configuration file and save it to the folder `colorschemes` in your Geany configuration directory (usually `~/.config/geany/colorschemes/`).
+
+For more information and detailed configuration instructions, see https://github.com/geany/geany-themes.
+
+

--- a/static_docs/github_client.py
+++ b/static_docs/github_client.py
@@ -30,9 +30,11 @@ class GitHubApiClient:
     """"""
 
     # ----------------------------------------------------------------------
-    def get_file_contents(self, filename):
-        url_parameters = dict(user=GITHUB_USER,
-                              repository=GITHUB_REPOSITORY,
+    def get_file_contents(self, filename, user=None, repository=None):
+        user = user or GITHUB_USER
+        repository = repository or GITHUB_REPOSITORY
+        url_parameters = dict(user=user,
+                              repository=repository,
                               filename=filename)
         url = 'https://api.github.com/repos/%(user)s/%(repository)s/contents/%(filename)s' % \
             url_parameters

--- a/static_docs/github_client.py
+++ b/static_docs/github_client.py
@@ -41,6 +41,7 @@ class GitHubApiClient:
         with requests.get(url, timeout=HTTP_REQUEST_TIMEOUT, stream=False) as response:
             response_json = response.json()
             self._log_rate_limit(response)
+            self._log_request(response)
 
         # parse response
         return self._parse_fetch_file_response(response_json)
@@ -50,6 +51,14 @@ class GitHubApiClient:
         rate_limit_remaining = response.headers['X-RateLimit-Remaining']
         rate_limit = response.headers['X-RateLimit-Limit']
         logger.info('Github rate limits: %s/%s', rate_limit_remaining, rate_limit)
+
+    # ----------------------------------------------------------------------
+    def _log_request(self, response):
+        logger.info(
+            'Requesting "{} {}" took {}s'.format(
+                response.request.method,
+                response.request.url,
+                response.elapsed.total_seconds()))
 
     # ----------------------------------------------------------------------
     def _parse_fetch_file_response(self, response_json):

--- a/static_docs/templates/pages/download/themes.html
+++ b/static_docs/templates/pages/download/themes.html
@@ -1,0 +1,63 @@
+{% extends "pages/richtextpage.html" %}
+
+{% load mezzanine_tags pages_tags static %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static "mezzanine/css/magnific-popup.css" %}">
+<style>
+    .img-thumbnail {
+        cursor: zoom-in;
+    }
+</style>
+{% endblock %}
+
+{% block richtext_content %}
+{{ block.super }}
+
+<h3>Available Themes</h3>
+
+<div class="row">
+
+{% for theme in theme_index.values|dictsort:"name" %}
+    <div class="col-md-4">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>{{ theme.name }}</strong>
+                <span class="pull-right"><a href="{{ theme.colorscheme }}">Download</a></span>
+            </div>
+            <div class="panel-body gallery">
+                <a href="{{ theme.screenshot }}" title="{{ theme.name }} - {{ theme.description }}">
+                    <img
+                        src="data:image/png;base64,{{ theme.thumbnail }}"
+                        class="img-responsive img-thumbnail center-block"
+                        alt="Thumbnail of colorscheme {{ theme.name }}" />
+                </a>
+                <div class="text-center">{{ theme.description }}</div>
+            </div>
+        </div>
+    </div>
+
+    {% if forloop.counter|divisibleby:3 %}
+        </div>
+        <div class="row">
+    {% endif %}
+{% endfor %}
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }}
+<script src="{% static "mezzanine/js/magnific-popup.js" %}"></script>
+<script>
+$(document).ready(function() {
+    $('.gallery').magnificPopup({
+        delegate: 'a',
+        type: 'image',
+        gallery: {
+            enabled: true,
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/static_docs/urls.py
+++ b/static_docs/urls.py
@@ -14,10 +14,12 @@
 
 from django.conf.urls import url
 
-from static_docs.views import I18NStatisticsView, ReleaseNotesView, ToDoView
+from static_docs.views import I18NStatisticsView, ReleaseNotesView, ThemesView, ToDoView
 
 
 urlpatterns = (  # pylint: disable=invalid-name
+    url(r'^download/themes/$', ThemesView.as_view(), name='themes'),
+
     url(r'^documentation/todo/$', ToDoView.as_view(), name='todo'),
 
     url(r'^documentation/releasenotes/$', ReleaseNotesView.as_view(), name='releasenotes'),


### PR DESCRIPTION
The themes in the preview list are loaded from the Geany-Themes
repository on Github on the fly (but cached for one hour).

- adds new menu item "Download -> Geany Themes"
- displays brief information about the Geany-Themes project
- list available themes with preview thumbnail and a gallery

Closes #5.

![website_geany_themes_preview](https://user-images.githubusercontent.com/617017/59974257-955dd400-9599-11e9-9355-2bbd8fc34667.png)
![website_geany_themes_gallery](https://user-images.githubusercontent.com/617017/59974283-ee2d6c80-9599-11e9-97a9-01df54a733d9.png)
