### PR TITLE
Add bank transfer as donating option

### DIFF
--- a/page_content/about/donate.md
+++ b/page_content/about/donate.md
@@ -15,9 +15,15 @@ More than financial support, the Geany project needs help with:
 
 If you want to donate money to the Geany project, it will be used to support further development of Geany, to pay running costs for hosting and domains and support presenting Geany on various [Open Source Conferences][5].
 
-Currently, the only available option to donate money is via Paypal. We are working on more options.
+Currently, there are two options to donate money: via bank transfer and Paypal.
+Bank transfer is the preferred way for donating money as the money is transferred directly without a third party involved and Paypal fees can be avoided.
 
-[Donate via Paypal ![Donate via Paypal][6]][7]
+Your options:
+
+  - Bank transfer:
+    IBAN: DE94830944950003429687
+    BIC: GENODEF1ETK
+  - [![Donate via Paypal][6] Donate via Paypal][7]
 
 
   [1]: /contribute/translation/


### PR DESCRIPTION
Since the Geany e.V. association opened a new bank account, we can also offer bank transfers which might be easier, more secure or for other reasons more comfortable for donaters.
Also Paypal fees can be avoided.