### PR TITLE
Add imprint on Geany e.V. association page

### DIFF
--- a/geany/settings.py
+++ b/geany/settings.py
@@ -19,6 +19,7 @@ import os
 import warnings
 
 from django.utils.translation import ugettext_lazy as _
+from markdown.extensions.toc import TocExtension
 
 
 ######################
@@ -382,7 +383,9 @@ PAGEDOWN_MARKDOWN_EXTENSIONS = (
     # markdown extensions
     'nl2br',
     'tables',
-    'toc',
+    # create TOC entries only for heading level 2 to 4
+    # level 1 usually is the page header, we don't need levels deeper than 4
+    TocExtension(toc_depth='2-4'),
 )
 
 #########################

--- a/page_content/association.md
+++ b/page_content/association.md
@@ -1,6 +1,10 @@
 Geany e.V. - the registered association for the Geany project
 =================================================
 
+**Contents**
+
+[TOC]
+
 ## About
 
 The association "Geany e.V." is registered in Stendal, Germany and is intended to represent the Geany project. The main goal is to provide a legal entity for the Geany project and to handle donated money.
@@ -75,13 +79,32 @@ The rules of order (Geschäftsordnung) are available at: [go.pdf](/media/uploads
 Unfortunately, currently the charter and rules of order documents are available only in German.
 
 
-## Contact
+## Imprint & Contact
 
-For any questions or requests, feel free to contact any or all of the board members.
+##### Represented by
 
-Enrico Tröger - enrico [dot] troeger [at] uvena.de
-Frank Lanitz - frank [at] lanitz [dot] info
-Silvio Knizek - silvio [dot] knizek [at] gmx [dot] de
+Geany e.V.
+c/o Enrico Tröger
+Vogelsanger Str. 169
+50823 Cologne
+Germany
+
+Email: association-board [at] geany [dot] org
+
+##### Board
+
+Enrico Tröger - chairman
+Frank Lanitz - treasurer
+Silvio Knizek - minutes secretary
+
+##### Association register entry
+
+Registering court: Amtsgericht Stendal (Germany)
+Registration number: 2477/16
+
+##### Contact
+
+For any questions or requests, feel free to contact the board members at association-board [at] geany [dot] org.
 
 For members communication, there is a mailing list at
 https://lists.geany.org/cgi-bin/mailman/listinfo/association-members.

--- a/page_content/support/mailing-lists.md
+++ b/page_content/support/mailing-lists.md
@@ -3,6 +3,8 @@ Mailing Lists
 
 For announcements, general discussing, coordinating development and more, we use mailing lists (read about at [Wikipedia][1]).
 
+Available mailing lists:
+
 [TOC]
 
 *   _Note: You must subscribe to a list before you can send mail to it_


### PR DESCRIPTION
We probably need this for German law and so add it to be safe.
It doesn't expose that much new information except for an already
present address.
![Screen Shot 2021-03-21 at 13 30 14-fullpage](https://user-images.githubusercontent.com/617017/111907002-58af5d00-8a4b-11eb-8353-878fe72a695f.png)