### PR TITLE
Update verify-gpg-signature.md

### DIFF
--- a/page_content/support/verify-gpg-signature.md
+++ b/page_content/support/verify-gpg-signature.md
@@ -1,9 +1,9 @@
 Verifying GPG signatures of Geany and Geany-Plugins releases
 ==========
 
-You can use the `gpg` utility. On GNU/Linux distributions, if you don't have it, you can get it with `sudo apt install gpg`. On other OS-es, see https://gnupg.org/download/index.html and https://gnupg.org/download/integrity_check.html. 
+You can use the `gpg` utility. On GNU/Linux distributions, if you don't have it, you can get it with `sudo apt install gpg`. On other other operating systems, see https://gnupg.org/download/index.html and https://gnupg.org/download/integrity_check.html. 
 
-Here is how to use `gpg` on Linux and related: 
+#### Here is how to use `gpg` on Linux-like distributions: 
 
 First, you need to import the public GPG key used to sign the packages. You can download the used public key from: https://download.geany.org/colombanw-pubkey.txt
 

--- a/page_content/support/verify-gpg-signature.md
+++ b/page_content/support/verify-gpg-signature.md
@@ -1,6 +1,10 @@
 Verifying GPG signatures of Geany and Geany-Plugins releases
 ==========
 
+You can use the `gpg` utility. On GNU/Linux distributions, if you don't have it, you can get it with `sudo apt install gpg`. On other OS-es, see https://gnupg.org/download/index.html and https://gnupg.org/download/integrity_check.html. 
+
+Here is how to use `gpg` on Linux and related: 
+
 First, you need to import the public GPG key used to sign the packages. You can download the used public key from: https://download.geany.org/colombanw-pubkey.txt
 
 To import the key use:


### PR DESCRIPTION
Added 2 lines at the top to explain users how to get `gpg`, of particular use for non-Linux users.

Fixes #34 