### PR TITLE
Add macOS arm64 build to downloads page

### DIFF
--- a/geany/templates/home.html
+++ b/geany/templates/home.html
@@ -51,7 +51,7 @@ Home
 				<p class="text-big">
 					Geany is a powerful, stable and lightweight programmer's text editor
 					that provides tons of useful features without bogging down your
-					workflow. It runs on Linux, Windows and MacOS is translated into
+					workflow. It runs on Linux, Windows and macOS is translated into
 					over 40 languages, and has built-in support for more than 50 programming
 					languages.
 					<a href="{% url 'page' 'download/releases' %}" class="btn btn-default btn-primary" id="main-download-button">

--- a/latest_version/releases.py
+++ b/latest_version/releases.py
@@ -24,6 +24,7 @@ RELEASE_TYPE_SOURCE_GZIP = 'source_gzip_version'
 RELEASE_TYPE_SOURCE_BZIP2 = 'source_bzip2_version'
 RELEASE_TYPE_WINDOWS = 'windows_version'
 RELEASE_TYPE_MACOS = 'macos_version'
+RELEASE_TYPE_MACOS_ARM64 = 'macos_version_arm64'
 
 RELEASE_TYPES = {
     settings.LATEST_VERSION_RELEASES_DIRECTORY: {
@@ -42,6 +43,10 @@ RELEASE_TYPES = {
         RELEASE_TYPE_MACOS: {
             'pattern': re.compile(r'^geany-([0-9\.\-]+)_osx(-[0-9]+)?.dmg$'),
             'fallback_filename': 'geany-{version}_osx.dmg'
+        },
+        RELEASE_TYPE_MACOS_ARM64: {
+            'pattern': re.compile(r'^geany-([0-9\.\-]+)_osx_arm64(-[0-9]+)?.dmg$'),
+            'fallback_filename': 'geany-{version}_osx_arm64.dmg'
         },
     },
 
@@ -71,6 +76,7 @@ class ReleaseVersions:
     source_bzip2_version = None
     windows_version = None
     macos_version = None
+    macos_version_arm64 = None
 
 
 class ReleaseVersionsProvider:

--- a/page_content/about/geany.md
+++ b/page_content/about/geany.md
@@ -18,7 +18,7 @@ Geany is a small and lightweight Integrated Development Environment. It was deve
   -  Simple project management
   -  Plugin interface (see [Plugins][2])
 
-Geany is known to run under Linux, FreeBSD, NetBSD, OpenBSD, MacOS X, AIX v5.3, Solaris Express and Windows. More generally, it should run on every platform, which is supported by the GTK libraries. Only the Windows port of Geany is missing some features.
+Geany is known to run under Linux, FreeBSD, NetBSD, OpenBSD, macOS, AIX v5.3, Solaris Express and Windows. More generally, it should run on every platform, which is supported by the GTK libraries. Only the Windows port of Geany is missing some features.
 
 The code is licensed under the terms of the [GNU General Public Licence][3].
 
@@ -30,7 +30,7 @@ The code is licensed under the terms of the [GNU General Public Licence][3].
   - Enrico Tröger (developer)
   - Frank Lanitz (translation maintainer)
   - Lex Trotman (regular contributor, support guru)
-  - Jiří Techet (regular contributor, MacOS expert)
+  - Jiří Techet (regular contributor, macOS expert)
   - and many other contributors, translators and patch writers
 
 ## Contact

--- a/page_content/download/releases.md
+++ b/page_content/download/releases.md
@@ -5,7 +5,7 @@ Distribution          | File          | GPG Signature | GPG Key
 Source (tar.gz)       | [{{ release_versions.source_gzip_version }}](https://download.geany.org/{{ release_versions.source_gzip_version }}) | [{{ release_versions.source_gzip_version }}.sig](https://download.geany.org/{{ release_versions.source_gzip_version }}.sig) ([Instructions][4]) | [colombanw-pubkey.txt][1]
 Source (tar.bz2)      | [{{ release_versions.source_bzip2_version }}](https://download.geany.org/{{ release_versions.source_bzip2_version }}) | [{{ release_versions.source_bzip2_version }}.sig](https://download.geany.org/{{ release_versions.source_bzip2_version }}.sig) ([Instructions][4]) | [colombanw-pubkey.txt][1]
 Windows (64-bit[^1])  | [{{ release_versions.windows_version }}](https://download.geany.org/{{ release_versions.windows_version }}) | [{{ release_versions.windows_version }}.sig](https://download.geany.org/{{ release_versions.windows_version }}.sig) ([Instructions][4]) | [eht16-pubkey.txt][2]
-Mac OSX               | [{{ release_versions.macos_version }}](https://download.geany.org/{{ release_versions.macos_version }}) | - | -
+Mac OSX               | [{{ release_versions.macos_version }}](https://download.geany.org/{{ release_versions.macos_version }})<br>[{{ release_versions.macos_version_arm64 }}](https://download.geany.org/{{ release_versions.macos_version_arm64 }}) | - | -
 
 [Release notes for Geany {{ geany_latest_version.version }}][3]
 

--- a/page_content/download/releases.md
+++ b/page_content/download/releases.md
@@ -5,7 +5,7 @@ Distribution          | File          | GPG Signature | GPG Key
 Source (tar.gz)       | [{{ release_versions.source_gzip_version }}](https://download.geany.org/{{ release_versions.source_gzip_version }}) | [{{ release_versions.source_gzip_version }}.sig](https://download.geany.org/{{ release_versions.source_gzip_version }}.sig) ([Instructions][4]) | [colombanw-pubkey.txt][1]
 Source (tar.bz2)      | [{{ release_versions.source_bzip2_version }}](https://download.geany.org/{{ release_versions.source_bzip2_version }}) | [{{ release_versions.source_bzip2_version }}.sig](https://download.geany.org/{{ release_versions.source_bzip2_version }}.sig) ([Instructions][4]) | [colombanw-pubkey.txt][1]
 Windows (64-bit[^1])  | [{{ release_versions.windows_version }}](https://download.geany.org/{{ release_versions.windows_version }}) | [{{ release_versions.windows_version }}.sig](https://download.geany.org/{{ release_versions.windows_version }}.sig) ([Instructions][4]) | [eht16-pubkey.txt][2]
-Mac OSX               | [{{ release_versions.macos_version }}](https://download.geany.org/{{ release_versions.macos_version }})<br>[{{ release_versions.macos_version_arm64 }}](https://download.geany.org/{{ release_versions.macos_version_arm64 }}) | - | -
+macOS                 | [{{ release_versions.macos_version }}](https://download.geany.org/{{ release_versions.macos_version }})<br>[{{ release_versions.macos_version_arm64 }}](https://download.geany.org/{{ release_versions.macos_version_arm64 }}) | - | -
 
 [Release notes for Geany {{ geany_latest_version.version }}][3]
 
@@ -20,7 +20,7 @@ Distribution          | File          | GPG Signature | GPG Key
 Source (tar.gz)       | [{{ plugins_release_versions.source_gzip_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_gzip_version }}) | [{{ plugins_release_versions.source_gzip_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_gzip_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
 Source (tar.bz2)      | [{{ plugins_release_versions.source_bzip2_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_bzip2_version }}) | [{{ plugins_release_versions.source_bzip2_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_bzip2_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
 Windows (64-bit[^1])  | [{{ plugins_release_versions.windows_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version }}) | [{{ plugins_release_versions.windows_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
-Mac OSX               | (included in `{{ release_versions.macos_version }}` above) | - | -
+macOS                 | (included in `{{ release_versions.macos_version }}` above) | - | -
 
 [Release notes for Geany-Plugins {{ geany_plugins_latest_version.version }}][7]
 


### PR DESCRIPTION
I'm now playing with an ARM64 build of Geany that runs natively on Apple's new M1 processors. I have a testing build in the snapshots directory and it seems to work quite well so I think it could be added to the downloads page.

I'm not sure if what I did in this pull request is enough (not tested at all) and if I haven't forgotten anything. There are a few macOS-related bugs I'd like to get fixed (or rather get user's feedback) before I put the final builds to the Downloads page so even if this pull request is considered fine, it shouldn't be merged yet.