### PR TITLE
Remove references to what was called Twitter once

### DIFF
--- a/geany/templates/home.html
+++ b/geany/templates/home.html
@@ -138,9 +138,8 @@ Home
 			platforms including
 			<a href="{% url "page" "support/mailing-lists" %}">The Mailing Lists</a>,
 			<a href="https://github.com/geany">Github</a>,
-			Matrix <a href="https://matrix.to/#/#geany:matrix.org">#geany:matrix.org</a>,
-			<a href="https://social.milchreislieferei.de/@GeanyIDE" rel="me">Mastodon</a> and
-			<a href="https://twitter.com/GeanyIDE/">Twitter</a>.</p>
+			Matrix <a href="https://matrix.to/#/#geany:matrix.org">#geany:matrix.org</a> and
+			<a href="https://social.milchreislieferei.de/@GeanyIDE" rel="me">Mastodon</a>.</p>
 			<p><a class="btn btn-default" href="{% url "page" "contribute" %}">Get Involved &raquo;</a>
 			   <a class="btn btn-default" href="{% url "page" "about/donate" %}">Donate &raquo;</a></p>
 	   </div>

--- a/page_content/contribute/support.md
+++ b/page_content/contribute/support.md
@@ -13,9 +13,9 @@ You can subscribe to the [Geany Users mailing list][1] and answer questions, giv
 
 You can also surf through the bugs reported at the [Github issue tracker][2] and see if you maybe can help users. Some issues reported are not actually bugs and maybe can be solved with your help.
 
-### Twitter
+### Mastodon / fediverse
 
-Geany's twitter stream: https://twitter.com/GeanyIDE/
+Geany in the Fediverse: https://social.milchreislieferei.de/@GeanyIDE
 
 
   [1]: /support/mailing-lists/


### PR DESCRIPTION
Since the Twitter account is not active anymore, remove our references to it.