### PR TITLE
Add code signing to releases page

### DIFF
--- a/page_content/download/releases.md
+++ b/page_content/download/releases.md
@@ -4,8 +4,8 @@ Distribution                    | File          | GPG Signature | GPG Key
 ------------------------------- | ------------- | ------------- | -------------
 Source (tar.gz)                 | [{{ release_versions.source_gzip_version }}](https://download.geany.org/{{ release_versions.source_gzip_version }}) | [{{ release_versions.source_gzip_version }}.sig](https://download.geany.org/{{ release_versions.source_gzip_version }}.sig) ([Instructions][4]) | [colombanw-pubkey.txt][1]
 Source (tar.bz2)                | [{{ release_versions.source_bzip2_version }}](https://download.geany.org/{{ release_versions.source_bzip2_version }}) | [{{ release_versions.source_bzip2_version }}.sig](https://download.geany.org/{{ release_versions.source_bzip2_version }}.sig) ([Instructions][4]) | [colombanw-pubkey.txt][1]
-Windows (64-bit[^1])            | [{{ release_versions.windows_version }}](https://download.geany.org/{{ release_versions.windows_version }}) | [{{ release_versions.windows_version }}.sig](https://download.geany.org/{{ release_versions.windows_version }}.sig) ([Instructions][4]) | [eht16-pubkey.txt][2]
-Windows (64-bit[^1], unsigned)  | [{{ release_versions.windows_version_unsigned }}](https://download.geany.org/{{ release_versions.windows_version_unsigned }}) | [{{ release_versions.windows_version_unsigned }}.sig](https://download.geany.org/{{ release_versions.windows_version_unsigned }}.sig) ([Instructions][4]) | [eht16-pubkey.txt][2]
+Windows (64-bit)                | [{{ release_versions.windows_version }}](https://download.geany.org/{{ release_versions.windows_version }}) | [{{ release_versions.windows_version }}.sig](https://download.geany.org/{{ release_versions.windows_version }}.sig) ([Instructions][4]) | [eht16-pubkey.txt][2]
+Windows (64-bit, unsigned)      | [{{ release_versions.windows_version_unsigned }}](https://download.geany.org/{{ release_versions.windows_version_unsigned }}) | [{{ release_versions.windows_version_unsigned }}.sig](https://download.geany.org/{{ release_versions.windows_version_unsigned }}.sig) ([Instructions][4]) | [eht16-pubkey.txt][2]
 macOS                           | [{{ release_versions.macos_version }}](https://download.geany.org/{{ release_versions.macos_version }})<br>[{{ release_versions.macos_version_arm64 }}](https://download.geany.org/{{ release_versions.macos_version_arm64 }}) | - | -
 
 [Release notes for Geany {{ geany_latest_version.version }}][3]
@@ -21,8 +21,8 @@ Distribution                    | File          | GPG Signature | GPG Key
 ------------------------------- | ------------- | ------------- | -------------
 Source (tar.gz)                 | [{{ plugins_release_versions.source_gzip_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_gzip_version }}) | [{{ plugins_release_versions.source_gzip_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_gzip_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
 Source (tar.bz2)                | [{{ plugins_release_versions.source_bzip2_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_bzip2_version }}) | [{{ plugins_release_versions.source_bzip2_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.source_bzip2_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
-Windows (64-bit[^1])            | [{{ plugins_release_versions.windows_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version }}) | [{{ plugins_release_versions.windows_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
-Windows (64-bit[^1], unsigned)  | [{{ plugins_release_versions.windows_version_unsigned }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version_unsigned }}) | [{{ plugins_release_versions.windows_version_unsigned }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version_unsigned }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
+Windows (64-bit)                | [{{ plugins_release_versions.windows_version }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version }}) | [{{ plugins_release_versions.windows_version }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
+Windows (64-bit, unsigned)      | [{{ plugins_release_versions.windows_version_unsigned }}](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version_unsigned }}) | [{{ plugins_release_versions.windows_version_unsigned }}.sig](https://plugins.geany.org/geany-plugins/{{ plugins_release_versions.windows_version_unsigned }}.sig) ([Instructions][4]) | [frlan-pubkey.txt][6]
 macOS                           | (included in `{{ release_versions.macos_version }}` above) | - | -
 
 [Release notes for Geany-Plugins {{ geany_plugins_latest_version.version }}][7]
@@ -53,5 +53,3 @@ For older versions, please see https://download.geany.org/.
 [5]: /support/plugins/
 [6]: https://download.geany.org/frlan-pubkey.txt
 [7]: https://raw.githubusercontent.com/geany/geany-plugins/{{ geany_plugins_latest_version.version }}/NEWS
-
-[^1]: *The Windows installers require a 64-bit system. Older releases work also on 32-bit Windows systems.*

--- a/page_content/download/releases.md
+++ b/page_content/download/releases.md
@@ -29,6 +29,10 @@ macOS                           | (included in `{{ release_versions.macos_versio
 
 For more details, see the [plugin page][5].
 
+## Code Signing Policy
+- Free code signing for the Windows binaries provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/)
+- This program will not transfer any information to other networked systems unless specifically requested by the user or the person installing or operating it
+- Approver: [Giuseppe Penone](https://github.com/giuspen)
 
 ## Older versions
 


### PR DESCRIPTION
The diff is a little ugly unfortunately.

I added the "Code Signing Policy" section and removed the "unsigned" installer variants.

Also, I removed the note that older releases are available for 32bit Windows. While this is still true, we switched to 64bit binaries in 2021 and I think this note is not relevant any longer.

It looks like:
<img width="1404" height="1312" alt="Screenshot 2025-07-14 at 22-10-31 Releases Geany" src="https://github.com/user-attachments/assets/f51cb446-cc3f-46e9-819a-0c43e2c8357c" />

