### PR TITLE
Move descriptive text below the screenshot carousel on the homepage

### DIFF
--- a/geany/templates/home.html
+++ b/geany/templates/home.html
@@ -50,14 +50,6 @@ Home
 			<div class="col-sm-4">
 				<p class="text-big">
 					Geany is a powerful, stable and lightweight programmer's text editor
-					that provides tons of useful features without bogging down your
-					workflow. It runs on Linux, Windows and macOS, is translated into
-					over 40 languages, and has built-in support for more than 50 programming
-					languages.
-					<a href="{% url 'page' 'download/releases' %}" class="btn btn-default btn-primary" id="main-download-button">
-						<span class="glyphicon glyphicon-save" aria-hidden="true"></span>
-						Download Geany {{ geany_latest_version.version }} &raquo;
-					</a>
 				</p>
 			</div>
 			<div class="col-sm-8">
@@ -105,6 +97,20 @@ Home
 				  </a>
 				</div>
 			</div>
+		</div>
+		<div class="row">
+			<p>
+				Geany provides tons of useful features without bogging
+				down your workflow. It runs on Linux, Windows and
+				macOS, is translated into over 40 languages, and has
+				built-in support for more than 50 programming languages.
+			</p>
+			<p>
+				<a href="{% url 'page' 'download/releases' %}" class="btn btn-default btn-primary" id="main-download-button">
+					<span class="glyphicon glyphicon-save" aria-hidden="true"></span>
+					Download Geany {{ geany_latest_version.version }} &raquo;
+				</a>
+			</p>
 		</div>
 	</div>
 


### PR DESCRIPTION
Closes #58.