### PR TITLE
Add OpenGraph tags to website for better link previews

### DIFF
--- a/geany/templates/skel.html
+++ b/geany/templates/skel.html
@@ -10,6 +10,19 @@
 <meta name="keywords" content="{% block meta_keywords %}{% endblock %}">
 <meta name="description" content="{% block meta_description %}{% endblock %}">
 <meta name="author" content="Geany development team"/>
+
+{% if page %}
+<meta property="og:title" content="{{ page.richtextpage.meta_title }} | {{ settings.SITE_TITLE }}">
+{% elif newspost %}
+<meta property="og:title" content="{{ newspost.title }} | {{ settings.SITE_TITLE }}">
+{% else %}
+<meta property="og:title" content="{{ settings.SITE_TITLE }} - The Flyweight IDE">
+{% endif %}
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}">
+<meta property="og:description" content="A powerful, stable and lightweight programmer's text editor">
+<meta property="og:image" content="https://geany.org/geany-logo.png">
+
 <title>{% block meta_title %}{% endblock %}{% if settings.SITE_TITLE %} | {{ settings.SITE_TITLE }}{% endif %}</title>
 <link rel="shortcut icon" href="{% static "favicon.ico" %}">
 


### PR DESCRIPTION
This is used at least by Mastodon and other Fediverse services.

Maybe it works also for services which generate link previews.

It's not perfect but better than the current state :).

Example (Mastodon):
<img width="591" height="192" alt="Screenshot_2026-03-15_23-01-21" src="https://github.com/user-attachments/assets/f4077ad2-fdc6-4642-a487-9a50d8a45ab6" />
